### PR TITLE
Fix `Show Properties` button throwing exception on Visual Studio 2022

### DIFF
--- a/PackageEditorPane.cs
+++ b/PackageEditorPane.cs
@@ -2414,7 +2414,8 @@ namespace Microsoft.OpenXMLEditor
                 {
                     // FindToolWindow fails sometimes if the property window is collapsed.
                     // Fire the PROPPAGE command key instead.
-                    EnvDTE.DTE dte = (EnvDTE.DTE)GetVsService(typeof(EnvDTE._DTE));
+                    EnvDTE80.DTE2 dte = (EnvDTE80.DTE2)GetVsService(typeof(EnvDTE._DTE));
+
                     if (dte != null)
                         dte.ExecuteCommand("View.PropertiesWindow", "");
                 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
 [assembly: AssemblyTitle("Open XML Package Editor for Visual Studio")]
 [assembly: AssemblyDescription("Open XML Package Editor for Visual Studio")]
 [assembly: AssemblyCompany("Borislav Ivanov")]

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,7 @@
-﻿v.2.0.0
+﻿v.2.0.1
+Fix `Show Properties` buttons throwing exception in Visual Studio 2022.
+
+v.2.0.0
 Add support for Visual Studio 2022
 Drop support for Visual Studio 2015 and below. You can install compatible version from https://github.com/bsivanov/Open-XML-Package-Editor-Power-Tool-for-Visual-Studio/releases/tag/v1.1.0.
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ac41218c-c632-413c-b108-a9ecbbaabb90" Version="2.0.0" Language="en-US" Publisher="Borislav Ivanov"/>
+        <Identity Id="ac41218c-c632-413c-b108-a9ecbbaabb90" Version="2.0.1" Language="en-US" Publisher="Borislav Ivanov"/>
         <DisplayName>Open XML Package Editor for Modern Visual Studios</DisplayName>
         <Description xml:space="preserve">Parse and edit Open Packaging Conventions files, including Word, Excel, PowerPoint and Visio documents. Fork of the original Open XML Package Editor for Visual Studio extension by Microsoft.</Description>
         <License>eula.1033.txt</License>


### PR DESCRIPTION
In Visual Studio 2022, `_DTE` cannot be casted to `DTE`, so use `DTE2` as advised in [Breaking API changes in Visual Studio 2022](https://docs.microsoft.com/en-us/visualstudio/extensibility/migration/breaking-api-list?view=vs-2022#dte-and-_dte-type-cast-failures) guide.

Closes #6.